### PR TITLE
Fix typo in conceptual-specifications.md

### DIFF
--- a/conceptual-specifications.md
+++ b/conceptual-specifications.md
@@ -1,6 +1,6 @@
 # Conceptual specifications
 
-This article is about the idea behind Hexlet lessons and non-technical specifications. For technical specifications, please refer to [Technical specifications for lesson](theory-specifications.md).
+This article is about the idea behind Hexlet lessons and non-technical specifications. For technical specifications, please refer to [Technical specifications for lesson](technical-specifications.md).
 
 ## Overview
 


### PR DESCRIPTION
Fix the link to "Technical specifications for lesson"
